### PR TITLE
Fix _log_interfaces function when ns is an int

### DIFF
--- a/calico_kubernetes/calico_kubernetes.py
+++ b/calico_kubernetes/calico_kubernetes.py
@@ -774,7 +774,8 @@ def _log_interfaces(namespace):
         namespaces = check_output(['ip', 'netns', 'list'])
         logger.debug("Namespaces:\n%s", namespaces)
 
-        namespace_interfaces = check_output(['ip', 'netns', 'exec', namespace,
+        namespace_interfaces = check_output(['ip', 'netns',
+                                             'exec', str(namespace),
                                              'ip', 'addr'])
         logger.debug("Interfaces in namespace %s:\n%s",
                      namespace, namespace_interfaces)


### PR DESCRIPTION
_log_interfaces didn't handle the case where the ns was an int.

Explicitly cast to a string in the function, for safety.
